### PR TITLE
Add support for artifacts

### DIFF
--- a/examples/youtubedl.sh
+++ b/examples/youtubedl.sh
@@ -4,11 +4,12 @@ set -e -x -o pipefail
 
 # Example by Alex Ellis
 
-# https://www.youtube.com/watch?v=zcq1LQq08lk
+# https://www.youtube.com/watch?v=tPEE9ZwTmy0
 
 sudo curl -LSls -o /usr/local/bin/yt-dlp \
   https://github.com/yt-dlp/yt-dlp/releases/download/2023.11.16/yt-dlp_linux && \
   sudo chmod +x /usr/local/bin/yt-dlp
 
-yt-dlp -o "video.flv" "https://www.youtube.com/watch?v=zcq1LQq08lk" && \
-    du -h -d 0 video.flv
+yt-dlp -o "video.flv" "https://www.youtube.com/watch?v=tPEE9ZwTmy0" && \
+  du -h -d 0 video.flv && \
+  cp video.flv ./upload/

--- a/templates/workflow.yaml
+++ b/templates/workflow.yaml
@@ -12,6 +12,17 @@ on:
       - master
       - main
 
+permissions:
+  contents: write
+  checks: write
+
+  actions: read
+  issues: read
+  packages: write
+  pull-requests: read
+  repository-projects: read
+  statuses: read
+
 jobs:
   workflow:
     name: {{ .Name }}
@@ -20,6 +31,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Run the job
         run: |
+          mkdir -p upload
           chmod +x ./job.sh
           ./job.sh
 {{if gt (len .Secrets) 0}}
@@ -29,3 +41,10 @@ jobs:
       {{- end }}
 
 {{- end }}
+
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: ignore
+          path: ./upload/**/*
+          retention-days: 1

--- a/templates/workflow_test.go
+++ b/templates/workflow_test.go
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Run the job
         run: |
+          mkdir -p upload
           chmod +x ./job.sh
           ./job.sh
 `
@@ -58,7 +59,6 @@ func Test_Workflow_WithSecrets(t *testing.T) {
 			"OPENFAAS_GATEWAY": "OPENFAAS_GATEWAY",
 			"OPENFAAS_URL":     "OPENFAAS_URL",
 		},
-		WithSecrets: true,
 	})
 
 	if err != nil {
@@ -86,6 +86,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Run the job
         run: |
+          mkdir -p upload
           chmod +x ./job.sh
           ./job.sh
 


### PR DESCRIPTION
## Description

Add support for artifacts

This requires a GitHub App in order to access the download artifact endpoint. A personal access token cannot be used at present.
