### PR TITLE
Embed the default workflow.yaml template

### DIFF
--- a/templates/render.go
+++ b/templates/render.go
@@ -2,22 +2,28 @@ package templates
 
 import (
 	"bytes"
+	_ "embed"
 	"log"
 	"os"
 	"text/template"
 )
 
+//go:embed workflow.yaml
+var defaultWorkflow string
+
 func Render(p RenderParams) (string, error) {
+	var workflowT *template.Template
+	relativeTmplPath := "./workflow.yaml"
 
-	tmplPath := "./templates/workflow.yaml"
-	if _, err := os.Stat(tmplPath); err != nil && os.IsNotExist(err) {
-		tmplPath = "./workflow.yaml"
-	}
+	if _, err := os.Stat(relativeTmplPath); err == nil {
+		tmpl := template.Must(template.ParseFiles(relativeTmplPath))
+		workflowT, err = tmpl.ParseFiles(relativeTmplPath)
 
-	tmpl := template.Must(template.ParseFiles(tmplPath))
-	workflowT, err := tmpl.ParseFiles(tmplPath)
-	if err != nil {
-		log.Panicf("failed to parse workflow template: %s", err)
+		if err != nil {
+			log.Panicf("failed to parse workflow template: %s", err)
+		}
+	} else {
+		workflowT = template.Must(template.New("workflow").Parse(defaultWorkflow))
 	}
 
 	buf := bytes.NewBuffer(nil)


### PR DESCRIPTION
This PR embeds the default `workflow.yml` template so that the executable can be installed via `go install` and ran from any directory without needing to be executed from the actions-batch directory in order to use the default template. I was inspired to do this because, as a go dev, I installed actions-batch via the idiomatic go cmd:
`go install github.com/alexellis/actions-batch@latest`
and ran into an error about a missing `workflow.yml`. Admittedly, the README clearly states to checkout the repo and doesn't mention `go install`. However, my thought was that this change enables the standard way of installing go executables and preserves the previous documented ways of using the program.

In addition, I sought to preserve the previous behavior of falling back to a `./workflow.yml` template in the event the command _was_ being run from outside the actions-batch directory by flippin' the logic around. In this PR, it checks to see if there is a relative `./workflow.yml` and will use that if it is present, otherwise it will use the embedded default template.

The template tests pass w/o any changes and I tested the relative workflow.yml manually. Let me know if this is something you'd like to add or not, just thought I'd crank it out and see what ya think!