### PR TITLE
Handle new comments in dockerfile

### DIFF
--- a/examples/export-docker-image.sh
+++ b/examples/export-docker-image.sh
@@ -11,7 +11,7 @@ set -e -x -o pipefail
 
 mkdir -p uploads
 
-cat > Dockerfile <<EOF
+cat <<'EOF' >Dockerfile
 FROM alpine:latest
 
 RUN apk --no-cache add curl
@@ -23,4 +23,4 @@ docker build -t curl:latest .
 
 # export the image to a tar file
 
-docker save curl:latest > uploads/curl.tar
+docker save curl:latest >uploads/curl.tar


### PR DESCRIPTION
This fixes if the Dockerfile has comments in it. Need to `'` single-quote `EOF` to make it work

Without fix: https://github.com/Moulick/trusting_beaver1/actions/runs/8123356472/job/22203689781
With fix: https://github.com/Moulick/dazzling_darwin0/actions/runs/8123542099/job/22204059056

The run with the fix failed due to issue with my testing dockerfile, unrelated to this fix.