### PR TITLE
Add support for uploading additional files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.secrets
 /example/.secrets
 /out/**
+token.txt

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:latest
+
+RUN apk --no-cache add curl
+
+ENTRYPOINT ["curl"]

--- a/examples/existing-dockerfile.sh
+++ b/examples/existing-dockerfile.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e -x -o pipefail
+
+# Example by Moulick Aggarwal
+
+# Build a existing Dockerfile and then export a Docker image to a tar file
+# The exported file can then be imported into your local library via:
+
+# docker load -i curl.tar
+
+mkdir -p uploads
+
+docker build -t curl:latest .
+
+# export the image to a tar file
+
+docker save curl:latest > uploads/curl.tar

--- a/templates/workflow.yaml
+++ b/templates/workflow.yaml
@@ -31,7 +31,7 @@ jobs:
     name: {{ .Name }}
     runs-on: {{ .RunsOn }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Run the job
         run: |
           echo "HAS_UPLOADS=0" >> $GITHUB_ENV


### PR DESCRIPTION
Add support for uploading additional files that could be used in `jobs.sh`. Prime example being a existing `Dockerfile`. The `--additional-file` flag can be given multiple file to provide multiple files.

Closes #11 
